### PR TITLE
S3_error_eliminate

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -78,9 +78,9 @@ group :development, :test do
   gem 'capistrano3-unicorn'
 end
 
-gem "carrierwave"
-gem "mini_magick"
-gem 'fog-aws'
+gem "carrierwave"  #確認済み
+gem "mini_magick"  #確認済み
+gem 'fog-aws'      #確認済み
 
 gem 'devise-better_routes'
 gem 'recaptcha', require: 'recaptcha/rails'

--- a/app/uploaders/image_uploader.rb
+++ b/app/uploaders/image_uploader.rb
@@ -11,7 +11,7 @@ class ImageUploader < CarrierWave::Uploader::Base
   process resize_to_fit: [800, 800]
   # Choose what kind of storage to use for this uploader:
   # storage :file
-  storage :fog
+  storage :fog  #storageをfileに切り替えた場合うまく保存される。
 
   # Override the directory where uploaded files will be stored.
   # This is a sensible default for uploaders that are meant to be mounted:

--- a/config/initializers/carrierwave.rb
+++ b/config/initializers/carrierwave.rb
@@ -9,10 +9,10 @@ CarrierWave.configure do |config|
     provider: 'AWS',
     aws_access_key_id: Rails.application.secrets.aws_access_key_id,
     aws_secret_access_key: Rails.application.secrets.aws_secret_access_key,
-    region: 'ap-northeast-1'
+    region: 'ap-northeast-1' #リージョン確認済み
   }
 
-  config.fog_directory  = 'kyon-mercari'
+  config.fog_directory  = 'kyon-mercari' #バケット名確認済み
   config.asset_host = 'https://s3-ap-northeast-1.amazonaws.com/kyon-mercari'
 end
 


### PR DESCRIPTION
## 問題点
S3導入について、ローカルからはS3に画像の保存をを行うことができるが、本番環境で行った際にproduction.logに下記のエラーがでる。

D, [2018-11-08T11:47:50.256082 #4297] DEBUG -- : [8fa5c257-a5ee-4ee4-a582-cfcf3a8dd07a]    (2.2ms)  ROLLBACK
I, [2018-11-08T11:47:50.256645 #4297]  INFO -- : [8fa5c257-a5ee-4ee4-a582-cfcf3a8dd07a] Completed 500 Internal Server Error in 286ms (ActiveRecord: 3.7ms)
F, [2018-11-08T11:47:50.258204 #4297] FATAL -- : [8fa5c257-a5ee-4ee4-a582-cfcf3a8dd07a]   
F, [2018-11-08T11:47:50.258305 #4297] FATAL -- : [8fa5c257-a5ee-4ee4-a582-cfcf3a8dd07a] Excon::Error::Forbidden (Expected(200) <=> Actual(403 Forbidden)
excon.error.response

  :headers       => {
    "Connection"       => "close"
    "Content-Type"     => "application/xml"
    "Date"             => "Thu, 08 Nov 2018 11:47:49 GMT"
    "Server"           => "AmazonS3"
    "x-amz-id-2"       => "OA//lmamb1TvlJvYrZu60RU4/400czata3qGguW9ItnBwDn+Wjui6IWRsVhwabPKKBniVjXdYzs="
    "x-amz-request-id" => "90D744076030139D"
  }
  :host          => "kyon-mercari.s3-ap-northeast-1.amazonaws.com"
  :local_address => "172.31.47.55"
  :local_port    => 42646
  :path          => "/uploads/image/image/25/cap_1.jpg"
  :port          => 443
  :reason_phrase => "Forbidden"
  :remote_ip     => "52.219.68.27"
  :status        => 403
  :status_line   => "HTTP/1.1 403 Forbidden\r\n"

## 確認した事項
・ローカルからS3に画像が保存されていること。
・image_uploderのstorage :fogをstorage: fileに変更すると本番環境で保存したい画像がmysqlに保存される。
・.bash_pofileに記述してあるsecret_key等がローカル、本番同じであること。
・carrierwave.rbのリージョン、バケット名。
・ec2のアプリケーションファイルにsecret.ymlが存在していること
・gem "carrierwave"  ,"mini_magick",  'fog-aws'がproduction環境にもあること

## 試したこと
・EC２インスタンスの停止、開始
・enginx,unicorn,mysqlの再起動
・.bashrcが読み込まれている可能性があるということで、そちらにも.bash_profileと同じ記述をする
・sudo ntpd -q -p 1.jp.pool.ntp.orgの実行。

## 
もしよろしければアドバイスやご指摘いただけるでしょうか。
よろしくお願いいたします。

